### PR TITLE
Add cron and ignore-post-commit-hooks arguments to pollscm

### DIFF
--- a/jenkins_jobs/modules/triggers.py
+++ b/jenkins_jobs/modules/triggers.py
@@ -507,6 +507,10 @@ def pollscm(parser, xml_parent, data):
     Poll the SCM to determine if there has been a change.
 
     :arg string pollscm: the polling interval (cron syntax)
+           .. deprecated:: 1.1.0  Please use cron argument
+
+    :arg string cron: cron syntax of when to run (default '')
+    :arg bool ignore-post-commit-hooks: ignore post commit hooks
 
     Example:
 
@@ -515,7 +519,13 @@ def pollscm(parser, xml_parent, data):
     """
 
     scmtrig = XML.SubElement(xml_parent, 'hudson.triggers.SCMTrigger')
-    XML.SubElement(scmtrig, 'spec').text = data
+    if type(data) == str:
+        XML.SubElement(scmtrig, 'spec').text = data
+        logger.warn("pollscm string format is deprecated please use 'spec'")
+    else:
+        XML.SubElement(scmtrig, 'spec').text = data.get('cron', '')
+        XML.SubElement(scmtrig, 'ignorePostCommitHooks').text = str(
+            data.get('ignore-post-commit-hooks', 'false')).lower()
 
 
 def build_pollurl_content_type(xml_parent, entries, prefix,

--- a/tests/triggers/fixtures/pollscm002.xml
+++ b/tests/triggers/fixtures/pollscm002.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <triggers class="vector">
+    <hudson.triggers.SCMTrigger>
+      <spec>*/15 * * * *</spec>
+      <ignorePostCommitHooks>true</ignorePostCommitHooks>
+    </hudson.triggers.SCMTrigger>
+  </triggers>
+</project>

--- a/tests/triggers/fixtures/pollscm002.yaml
+++ b/tests/triggers/fixtures/pollscm002.yaml
@@ -1,0 +1,4 @@
+triggers:
+  - pollscm: 
+      cron: "*/15 * * * *"
+      ignore-post-commit-hooks: true


### PR DESCRIPTION
Argument cron replaces current syntax of:
- pollscm: "\* \* \* \* *"
  with:
- pollscm:
   cron: "\* \* \* \* *"

The old syntax is still supported but will log a deprecation
warning.  The new syntax allows supporting additional arguments.

Argument ignore-post-commit-hooks adds new boolean element
ignorePostCommitHooks.

Change-Id: I2b0d892545b9969bc9a143962447826e727e2ba9
